### PR TITLE
switchbotのAPI呼び出しを共通化する

### DIFF
--- a/.app.code-workspace
+++ b/.app.code-workspace
@@ -9,12 +9,16 @@
     {
       "path": "./scanner"
     },
+    {
+      "path": "./switchbot"
+    },
   ],
   "settings": {
     "files.exclude": {
       // hide first-level folders from root
       "recorder": true,
       "scanner": true,
+      "switchbot": true,
     }
   }
 }

--- a/fluentbit/README.md
+++ b/fluentbit/README.md
@@ -1,7 +1,0 @@
-## デプロイ
-TODO: ansibleなりスクリプトなり作る
-
-* `/opt/fluentbit`ディレクトリを作る
-* その配下に`fluent-bit.conf`を置く
-* 同配下にGCPのサービスアカウントのjsonを置き、`creds.json`でsymlinkする
-* `docker run -d --name fluentbit -p 9880:9880 -v /opt/fluentbit:/opt cr.fluentbit.io/fluent/fluent-bit -c /opt/fluent-bit.conf`

--- a/fluentbit/fluent-bit.conf
+++ b/fluentbit/fluent-bit.conf
@@ -1,9 +1,0 @@
-[INPUT]
-    Name  http
-
-[OUTPUT]
-    Name       bigquery
-    Match      *
-    google_service_credentials /opt/creds.json
-    dataset_id switchbot
-    table_id   metrics

--- a/switchbot/api.go
+++ b/switchbot/api.go
@@ -1,0 +1,84 @@
+package switchbot
+
+import (
+	"crypto/hmac"
+	"crypto/rand"
+	"crypto/sha256"
+	"encoding/base64"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"strconv"
+	"time"
+)
+
+type DevicesSchema struct {
+	StatusCode int `json:"statusCode"`
+	Body       struct {
+		DeviceList []struct {
+			DeviceId           string `json:"deviceId"`
+			DeviceName         string `json:"deviceName"`
+			DeviceType         string `json:"deviceType"`
+			EnableCloudService bool   `json:"enableCloudService"`
+			HubDeviceId        string `json:"hubDeviceId"`
+		} `json:"deviceList"`
+		InfraredRemoteList []struct {
+			DeviceId    string `json:"deviceId"`
+			DeviceName  string `json:"deviceName"`
+			RemoteType  string `json:"remoteType"`
+			HubDeviceId string `json:"hubDeviceId"`
+		} `json:"infraredRemoteList"`
+	} `json:"body"`
+	Message string `json:"message"`
+}
+
+func FetchDevices(token string, secret string) (*DevicesSchema, error) {
+	resp, err := switchbotGet("https://api.switch-bot.com/v1.1/devices", token, secret)
+	if err != nil {
+		return nil, err
+	}
+	defer resp.Body.Close()
+
+	var data DevicesSchema
+
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return nil, err
+	}
+
+	if err := json.Unmarshal(body, &data); err != nil {
+		return nil, err
+	}
+
+	return &data, nil
+}
+
+func switchbotGet(url string, token string, secret string) (*http.Response, error) {
+	// https://github.com/OpenWonderLabs/SwitchBotAPI/blob/21f905ba96147028d85517b517beef3a2d66bb50/README.md#authentication
+
+	// SecureRandom.hex(16)
+	k := make([]byte, 16)
+	if _, err := rand.Read(k); err != nil {
+		panic(err)
+	}
+	nonce := fmt.Sprintf("%x", k)
+
+	time := strconv.FormatInt(time.Now().UnixMilli(), 10)
+
+	h := hmac.New(sha256.New, []byte(secret))
+	h.Write([]byte(token + time + nonce))
+	sig := h.Sum(nil)
+	sign := base64.StdEncoding.EncodeToString(sig)
+
+	req, err := http.NewRequest("GET", url, nil)
+	if err != nil {
+		return nil, err
+	}
+	req.Header.Set("Authorization", token)
+	req.Header.Set("sign", sign)
+	req.Header.Set("nonce", nonce)
+	req.Header.Set("t", time)
+
+	return http.DefaultClient.Do(req)
+}

--- a/switchbot/go.mod
+++ b/switchbot/go.mod
@@ -1,0 +1,3 @@
+module github.com/cumet04/switchbot-logger/switchbot
+
+go 1.20


### PR DESCRIPTION
recorderとviewerで同じコードを使うので、moduleとして共通化したい。

妥当に考えればトップレベルにディレクトリを切って相対パスで読み込めばよいのだが、CloudFunctionの制約として
* ソースコード（ビルドコンテキスト）のトップレベルにgo.modやらfunction.goやらが必要
* 上記「ソースコード」以外にファイルを含むことはできない（親階層にあるmoduleを読み出せない）

という問題がある。

他にも迂回路はありそうだが、本件の場合はmoduleのコードを頻繁に変更するわけではないので、いっそmainにmergeしてリモート参照すればいいか。ということになった。

というわけで、先にmoduleだけをmergeする