### PR TITLE
メトリクス取得の死活監視を入れる

### DIFF
--- a/infra/src/bigquery.ts
+++ b/infra/src/bigquery.ts
@@ -5,6 +5,7 @@ import {
   BigqueryTableConfig,
   BigqueryTable as gBigqueryTable,
 } from '@cdktf/provider-google/lib/bigquery-table';
+import {BigqueryDataTransferConfig} from '@cdktf/provider-google/lib/bigquery-data-transfer-config';
 
 export class BigqueryTable extends BaseConstruct {
   constructor(
@@ -32,6 +33,33 @@ export class BigqueryDataset extends BaseConstruct {
     new gBigqueryDataset(this, 'this', {
       datasetId,
       location: this.gcpLocation,
+    });
+  }
+}
+
+export class ScheduledQuery extends BaseConstruct {
+  constructor(
+    scope: Construct,
+    config: {
+      displayName: string;
+      schedule: string;
+      query: string;
+      email: boolean;
+    }
+  ) {
+    const {displayName, schedule, query, email} = config;
+
+    super(scope, `ScheduledQuery_${displayName}`);
+
+    new BigqueryDataTransferConfig(this, 'this', {
+      displayName,
+      dataSourceId: 'scheduled_query',
+      location: this.gcpLocation,
+      schedule,
+      emailPreferences: {
+        enableFailureEmail: email,
+      },
+      params: {query},
     });
   }
 }

--- a/infra/src/main.ts
+++ b/infra/src/main.ts
@@ -2,7 +2,7 @@ import {Construct} from 'constructs';
 import {App, GcsBackend, TerraformStack, TerraformVariable} from 'cdktf';
 import {GoogleProvider} from '@cdktf/provider-google/lib/provider';
 import {ServiceAccount} from './serviceAccount';
-import {BigqueryDataset, BigqueryTable} from './bigquery';
+import {BigqueryDataset, BigqueryTable, ScheduledQuery} from './bigquery';
 import {Secret} from './secretManager';
 import {AppContext} from './baseConstruct';
 import {CloudRun} from './cloudRun';
@@ -42,7 +42,7 @@ class MyStack extends TerraformStack {
 
     this.setupCloudRunApp(env);
 
-    this.setupMetricsTable();
+    this.setupMetricsTable(env);
   }
 
   private setupCloudRunApp(env: EnvType): void {
@@ -81,9 +81,11 @@ class MyStack extends TerraformStack {
     });
   }
 
-  private setupMetricsTable(): void {
+  private setupMetricsTable(env: EnvType): void {
     new BigqueryDataset(this, 'switchbot');
 
+    const datasetId = 'switchbot';
+    const tableId = 'metrics';
     const schema = Object.entries({
       Time: 'TIMESTAMP',
       DeviceId: 'STRING',
@@ -94,11 +96,25 @@ class MyStack extends TerraformStack {
       name,
       type,
     }));
-    new BigqueryTable(this, 'switchbot', 'metrics', JSON.stringify(schema), {
+    new BigqueryTable(this, datasetId, tableId, JSON.stringify(schema), {
       timePartitioning: {
         type: 'DAY',
         field: 'Time',
       },
+    });
+
+    // MEMO: SELECT * ではなくCOUNTとかのほうが料金やすいかも？
+    const aliveQuery = [
+      'SELECT *',
+      `FROM ${datasetId}.${tableId}`,
+      'WHERE Time > DATETIME_SUB(CURRENT_TIMESTAMP(), INTERVAL 10 MINUTE)',
+    ].join(' ');
+    new ScheduledQuery(this, {
+      // displayNameはメール通知の件名に入るので、envを入れておく
+      displayName: `[${env.toUpperCase()}] switchbotメトリクス死活監視`,
+      schedule: 'every 10 minutes',
+      query: `ASSERT EXISTS ( ${aliveQuery} )`,
+      email: true,
     });
   }
 }


### PR DESCRIPTION
主にraspiが落ちてる場合を想定。
put metricのAPIの呼び出し回数を見ても良いのだが、せっかくなのでBQ側を見ることでAPI自体がミスってる場合の検知も兼ねる