### PR TITLE
budgetのCDKリソースIDがおかしなことになっていたのを修正

### DIFF
--- a/infra/src/billing.ts
+++ b/infra/src/billing.ts
@@ -21,8 +21,9 @@ export class BillingBudget extends BaseConstruct {
       rules: ThresholdRule[];
     }
   ) {
+    super(scope, 'BillingBudget'); // こうすると複数のBudgetを扱えないが、普通は複数作らないので問題ないはず
+
     const {name, targetProjectId, baseAmount, rules} = config;
-    super(scope, `BillingBudget_${name}`);
 
     new gBillingBudget(this, 'this', {
       billingAccount: this.gcpBillingAccount,


### PR DESCRIPTION
CDKのIDにTF_VARを使っていたため、IDにTfTokenTOKEN0みたいな内部の値が展開されてしまっていた。 これだとなにかの拍子にIDが変わってしまうことがありそうなので、TF_VARに依存しなそうな値にした