### PR TITLE
workloadIdentityの条件を厳しくしておく

### DIFF
--- a/infra/src/main.ts
+++ b/infra/src/main.ts
@@ -85,7 +85,7 @@ class MainStack extends BaseStack {
       'storage.objects.list',
     ]).account;
     new WorkloadIdentityResources(this, 'ghactions', {
-      repositoryName: 'cumet04/switchbot-logger',
+      repositoryId: '524107595',
       serviceAccount,
     });
   }

--- a/infra/src/workloadIdentity.ts
+++ b/infra/src/workloadIdentity.ts
@@ -13,7 +13,7 @@ export class WorkloadIdentityResources extends BaseConstruct {
     name: string,
     config: {
       serviceAccount: ServiceAccount;
-      repositoryName: string;
+      repositoryId: string;
     }
   ) {
     super(scope, 'WorkloadIdentity');
@@ -28,8 +28,9 @@ export class WorkloadIdentityResources extends BaseConstruct {
       workloadIdentityPoolId: pool.workloadIdentityPoolId,
       attributeMapping: {
         'google.subject': 'assertion.sub',
-        'attribute.repository': 'assertion.repository',
+        'attribute.repository_id': 'assertion.repository_id',
       },
+      attributeCondition: `assertion.repository_id == '${config.repositoryId}'`,
       oidc: {
         issuerUri: 'https://token.actions.githubusercontent.com',
       },
@@ -38,7 +39,7 @@ export class WorkloadIdentityResources extends BaseConstruct {
     new ServiceAccountIamMember(this, `member_${name}`, {
       serviceAccountId: config.serviceAccount.id,
       role: 'roles/iam.workloadIdentityUser',
-      member: `principalSet://iam.googleapis.com/${pool.name}/attribute.repository/${config.repositoryName}`,
+      member: `principalSet://iam.googleapis.com/${pool.name}/attribute.repository_id/${config.repositoryId}`,
     });
   }
 }


### PR DESCRIPTION
GCPからAdvisory Notificationsが届いていたので対応

* 利用元リポジトリについて、サービスアカウント側のプリンシパルの絞りだけでなくpool側の絞りも足した
  - これがGCPからのメール通知の本命
  - もともとサービスアカウント側があるので、完全に無防備になっているわけではなかった
    - https://zenn.dev/komazarari/articles/githubactions-googlecloud-wi#workload-identity-%E3%83%97%E3%83%BC%E3%83%AB-%E3%81%AE%E4%BD%9C%E6%88%90
    - > 属性条件を指定しない場合はすべての GitHub Actions workflow が対象になります。後述のサービスアカウント側の設定で権限借用の範囲を限定しておけば、だれでもどこからでも使われてしまうようなことにはなりませんが、多くの場合はプール側でも制限しておくほうがよいでしょう。
* リポジトリ特定条件をnameからidに変更し、乗っ取り耐性を上げておいた
  - https://cloud.google.com/iam/docs/workload-identity-federation-with-deployment-pipelines?_ga=2.173713955.-1445327375.1712326972&hl=ja#conditions
  - > 重要: repository や repository_owner などの名前フィールドを使用すると、[サイバースクワッティング](https://en.wikipedia.org/wiki/Cybersquatting)や[タイポスクワッティング](https://en.wikipedia.org/wiki/Typosquatting)などの攻撃を受けるリスクが高くなります。GitHub リポジトリまたは GitHub 組織を削除すると、誰かが同じ名前で ID を確立できる可能性があります。この状況を防ぐには、代わりに数値 *_id フィールドを使用してください。これは一意であり、再利用できません。