### PR TITLE
CloudRunとかBuildとかのリージョンを引っ越し

### DIFF
--- a/infra/src/CloudRunApp.ts
+++ b/infra/src/CloudRunApp.ts
@@ -3,10 +3,31 @@ import {BaseConstruct} from './baseConstruct';
 import {Secret} from './constructs/secretManager';
 import {ServiceAccount} from './constructs/serviceAccount';
 import {CloudRun} from './constructs/cloudRun';
+import {CloudBuild} from './constructs/CloudBuild';
+import {ArRepository} from './constructs/arRepository';
 
 export class CloudRunApp extends BaseConstruct {
   constructor(scope: Construct) {
     super(scope, 'CloudRunApp');
+
+    const serviceName = 'app';
+
+    const repo = new ArRepository(this, serviceName);
+
+    new CloudBuild(this, 'app', {
+      repo: repo.repo,
+      serviceName,
+      buildPermissions: ['secretmanager.versions.access'],
+      github: {
+        owner: 'cumet04',
+        name: 'switchbot-logger',
+        push: {
+          // mainが更新された場合は開発系も更新する
+          branch: this.env === 'production' ? '^main$' : `^(main|${this.env})$`,
+        },
+      },
+      buildYamlPath: 'app/cloudbuild.yaml',
+    });
 
     const token = new Secret(this, 'switchbot_token');
     const secret = new Secret(this, 'switchbot_secret');
@@ -23,9 +44,8 @@ export class CloudRunApp extends BaseConstruct {
       'secretmanager.versions.access',
     ]);
 
-    new CloudRun(this, 'app', {
+    new CloudRun(this, serviceName, {
       serviceAccount: sa,
-      buildPermissions: ['secretmanager.versions.access'],
       envvars: {
         PROJECT_ID: this.projectId.value,
         NEXT_PUBLIC_APP_ENV: this.env,
@@ -36,15 +56,6 @@ export class CloudRunApp extends BaseConstruct {
         SWITCHBOT_SECRET: secret,
         SENTRY_AUTH_TOKEN: sentryToken,
       },
-      github: {
-        owner: 'cumet04',
-        name: 'switchbot-logger',
-        push: {
-          // mainが更新された場合は開発系も更新する
-          branch: this.env === 'production' ? '^main$' : `^(main|${this.env})$`,
-        },
-      },
-      buildYamlPath: 'app/cloudbuild.yaml',
     });
   }
 }

--- a/infra/src/constructs/CloudBuild.ts
+++ b/infra/src/constructs/CloudBuild.ts
@@ -1,0 +1,55 @@
+import {Construct} from 'constructs';
+import {BaseConstruct} from '../baseConstruct';
+import {
+  CloudbuildTrigger,
+  CloudbuildTriggerGithub,
+} from '@cdktf/provider-google/lib/cloudbuild-trigger';
+import {ArtifactRegistryRepository} from '@cdktf/provider-google/lib/artifact-registry-repository';
+import {ServiceAccount} from './serviceAccount';
+
+export class CloudBuild extends BaseConstruct {
+  constructor(
+    scope: Construct,
+    name: string,
+    options: {
+      repo: ArtifactRegistryRepository;
+      serviceName: string;
+      buildPermissions?: string[];
+      github: CloudbuildTriggerGithub;
+      buildYamlPath: string;
+    }
+  ) {
+    super(scope, `CloudBuild_${name}`);
+
+    const buildAccount = new ServiceAccount(this, 'builder', [
+      ...this.CloudBuildServiceAccountPermissions(),
+      ...(options.buildPermissions ?? []),
+    ]);
+
+    new CloudbuildTrigger(this, 'trigger', {
+      name,
+      location: 'global',
+      filename: options.buildYamlPath,
+      github: options.github,
+      substitutions: {
+        _SERVICE_NAME: options.serviceName,
+        _REGION: this.gcpLocation,
+        _IMAGE_URL: `${options.repo.location}-docker.pkg.dev/${options.repo.project}/${options.repo.repositoryId}/main`,
+      },
+      serviceAccount: buildAccount.account.id,
+    });
+  }
+
+  private CloudBuildServiceAccountPermissions() {
+    return [
+      'artifactregistry.repositories.downloadArtifacts',
+      'artifactregistry.repositories.uploadArtifacts',
+      'iam.serviceAccounts.actAs',
+      'logging.logEntries.create',
+      'run.operations.get',
+      'run.services.get',
+      'run.services.update',
+      'secretmanager.versions.access',
+    ];
+  }
+}

--- a/infra/src/constructs/arRepository.ts
+++ b/infra/src/constructs/arRepository.ts
@@ -1,0 +1,17 @@
+import {Construct} from 'constructs';
+import {BaseConstruct} from '../baseConstruct';
+import {ArtifactRegistryRepository} from '@cdktf/provider-google/lib/artifact-registry-repository';
+
+export class ArRepository extends BaseConstruct {
+  public repo: ArtifactRegistryRepository;
+
+  constructor(scope: Construct, name: string) {
+    super(scope, `ArRepository_${name}`);
+
+    this.repo = new ArtifactRegistryRepository(this, 'repository', {
+      repositoryId: name,
+      format: 'DOCKER',
+      location: this.gcpLocation,
+    });
+  }
+}

--- a/infra/src/constructs/arRepository.ts
+++ b/infra/src/constructs/arRepository.ts
@@ -5,13 +5,13 @@ import {ArtifactRegistryRepository} from '@cdktf/provider-google/lib/artifact-re
 export class ArRepository extends BaseConstruct {
   public repo: ArtifactRegistryRepository;
 
-  constructor(scope: Construct, name: string) {
+  constructor(scope: Construct, name: string, options: {location: string}) {
     super(scope, `ArRepository_${name}`);
 
     this.repo = new ArtifactRegistryRepository(this, 'repository', {
       repositoryId: name,
       format: 'DOCKER',
-      location: this.gcpLocation,
+      location: options.location,
     });
   }
 }

--- a/infra/src/constructs/cloudRun.ts
+++ b/infra/src/constructs/cloudRun.ts
@@ -13,6 +13,7 @@ export class CloudRun extends BaseConstruct {
     scope: Construct,
     name: string,
     options: {
+      location: string;
       serviceAccount: ServiceAccount;
       envvars?: Record<string, string>;
       secrets?: Record<string, Secret>;
@@ -37,7 +38,7 @@ export class CloudRun extends BaseConstruct {
 
     const service = new CloudRunV2Service(this, 'service', {
       name,
-      location: this.gcpLocation,
+      location: options.location,
       template: {
         executionEnvironment: 'EXECUTION_ENVIRONMENT_GEN2',
         serviceAccount: options.serviceAccount.account.email,

--- a/infra/src/main.ts
+++ b/infra/src/main.ts
@@ -92,6 +92,8 @@ class MainStack extends BaseStack {
       'bigquery.tables.get',
       'bigquery.transfers.get',
       'cloudbuild.builds.get',
+      'cloudbuild.connections.get',
+      'cloudbuild.repositories.get',
       'iam.roles.get',
       'iam.serviceAccounts.get',
       'iam.serviceAccounts.getIamPolicy',


### PR DESCRIPTION
fix #50 

### 背景
artifact registryのリージョン間通信のコストがかかってて微妙なのと、ついでに #50 を対処しようとあれこれしたところ、CloudRunApp.tsに書いたコメントどおりの事象にぶつかった。

書いてあるとおりだが、一式をasia-northeast1で作成したところ、quota制限でそのリージョンではbuild動きません、みたいなエラーが出て、[参考URL](https://cloud.google.com/build/docs/locations#restricted_regions_for_some_projects)を見たらなんとも情報量の少ないよくわからん特記が書いてあり、対処のしようがない状態になった。

もうめんどくさいし、CloudRunのカスタムドメイン遅い問題もあるし、いっそ全部引っ越すか。ということで引っ越した

### メモ
* これやるならBQも引っ越したほうが良いような気もする。どうせテーブルのカラムのデバイスID/MACアドレス問題あるので、ゴリッと引っ越してもいいと思う
* CloudRunサービスの作り直し（ドメイン設定の作り直し）になるので、サービス断が発生する。が、raspi側はエラーしたデータは残るので、あとでリトライすればok
* CloudBuildのgithub connectionは手動で作る
* adminの方のapplyが必要