### PR TITLE
Bump lockfile

### DIFF
--- a/renovate.json5
+++ b/renovate.json5
@@ -14,6 +14,8 @@
         // FIXME: .node-versionのとメジャーバージョンをいい感じに合わせて処理できるか？
         "@types/node"
       ],
+      // MEMO: scheduleのフォーマット https://breejs.github.io/later/parsers.html#text
+      // playground https://codepen.io/antonlydike/full/Kgygpr
       "schedule": ["on the first day of the month"],
       "lockFileMaintenance": {
         "enabled": true,

--- a/renovate.json5
+++ b/renovate.json5
@@ -14,7 +14,11 @@
         // FIXME: .node-versionのとメジャーバージョンをいい感じに合わせて処理できるか？
         "@types/node"
       ],
-      "schedule": ["on the first day of the month"]
+      "schedule": ["on the first day of the month"],
+      "lockFileMaintenance": {
+        "enabled": true,
+        "schedule": ["on the 15th day of the month"]
+      }
     }
   ]
 }


### PR DESCRIPTION
普通のアップデートがmergeされたあとに発火が望ましいので、15日にしておいた。

通常のアップデート時に一緒にやってくれるのが望ましいのだけど、そういうオプションは見当たらなかった