### PR TITLE
バージョンマネージャ種別によらずまとめてPRする

### DIFF
--- a/renovate.json5
+++ b/renovate.json5
@@ -8,6 +8,7 @@
   "includePaths": ["infra/**"],
   "packageRules": [
     {
+      "groupName": "infra",
       "matchFileNames": ["infra/**"],
       "ignoreDeps": [
         // gtsの依存の@typescript-eslint/typescript-estreeのバージョンの対応を見ながら上げる


### PR DESCRIPTION
現状だとnode, npm, terraformがそれぞれ別々になる。infraはplanが通ればヨシ以外の区別は無いので、一緒にPRしてほしい。
* refs #77 #78 #79

たぶんこの設定でいけると思うが、確証は無い