### PR TITLE
見てないときや深夜にリクエスト関連で課金されないようにする

### DIFF
--- a/app/src/app/viewer/Refresher.tsx
+++ b/app/src/app/viewer/Refresher.tsx
@@ -17,7 +17,9 @@ export const Refresher = (props: { minutes: number }) => {
   useEffect(() => {
     setInterval(
       () => {
-        router.refresh();
+        // 開きっぱなしタブによる不要なリクエストを抑制する
+        // MEMO: この制御は現在playwrightではテストできない refs https://github.com/microsoft/playwright/issues/3570
+        if (!document.hidden) router.refresh();
       },
       1000 * 60 * props.minutes
     );

--- a/app/src/app/viewer/page.tsx
+++ b/app/src/app/viewer/page.tsx
@@ -1,4 +1,4 @@
-import { env } from "@/lib/envvars";
+import { appenv, env } from "@/lib/envvars";
 import switchbot from "@/lib/switchbot";
 import { Query } from "@/lib/bigquery";
 import { DeviceId, IdToMac, MacToId } from "@/lib/parser";
@@ -12,9 +12,13 @@ export const revalidate = 0;
 export default async function Page() {
   const [temperature, humidity, load] = await fetchChartData();
 
+  // 本番以外では動作確認などしやすいように短い時間で動作させる
+  // 1分より短くても良いが、更新時刻表示が分単位のため、確実に変化が起こる1分にしておく
+  const refresh = appenv() === "production" ? 10 : 1;
+
   return (
     <main>
-      <Refresher minutes={10} />
+      <Refresher minutes={refresh} />
       <Chart name="Temperature" data={temperature} />
       <Chart name="Humidity" data={humidity} />
       <Chart name="Load" data={load} />

--- a/e2e/package-lock.json
+++ b/e2e/package-lock.json
@@ -6,7 +6,7 @@
     "": {
       "name": "e2e",
       "dependencies": {
-        "@playwright/test": "^1.42.1"
+        "@playwright/test": "^1.45.1"
       },
       "devDependencies": {
         "@types/node": "^20.11.30",
@@ -268,17 +268,17 @@
       }
     },
     "node_modules/@playwright/test": {
-      "version": "1.42.1",
-      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.42.1.tgz",
-      "integrity": "sha512-Gq9rmS54mjBL/7/MvBaNOBwbfnh7beHvS6oS4srqXFcQHpQCV1+c8JXWE8VLPyRDhgS3H8x8A7hztqI9VnwrAQ==",
+      "version": "1.45.1",
+      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.45.1.tgz",
+      "integrity": "sha512-Wo1bWTzQvGA7LyKGIZc8nFSTFf2TkthGIFBR+QVNilvwouGzFd4PYukZe3rvf5PSqjHi1+1NyKSDZKcQWETzaA==",
       "dependencies": {
-        "playwright": "1.42.1"
+        "playwright": "1.45.1"
       },
       "bin": {
         "playwright": "cli.js"
       },
       "engines": {
-        "node": ">=16"
+        "node": ">=18"
       }
     },
     "node_modules/@types/json-schema": {
@@ -2226,31 +2226,31 @@
       }
     },
     "node_modules/playwright": {
-      "version": "1.42.1",
-      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.42.1.tgz",
-      "integrity": "sha512-PgwB03s2DZBcNRoW+1w9E+VkLBxweib6KTXM0M3tkiT4jVxKSi6PmVJ591J+0u10LUrgxB7dLRbiJqO5s2QPMg==",
+      "version": "1.45.1",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.45.1.tgz",
+      "integrity": "sha512-Hjrgae4kpSQBr98nhCj3IScxVeVUixqj+5oyif8TdIn2opTCPEzqAqNMeK42i3cWDCVu9MI+ZsGWw+gVR4ISBg==",
       "dependencies": {
-        "playwright-core": "1.42.1"
+        "playwright-core": "1.45.1"
       },
       "bin": {
         "playwright": "cli.js"
       },
       "engines": {
-        "node": ">=16"
+        "node": ">=18"
       },
       "optionalDependencies": {
         "fsevents": "2.3.2"
       }
     },
     "node_modules/playwright-core": {
-      "version": "1.42.1",
-      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.42.1.tgz",
-      "integrity": "sha512-mxz6zclokgrke9p1vtdy/COWBH+eOZgYUVVU34C73M+4j4HLlQJHtfcqiqqxpP0o8HhMkflvfbquLX5dg6wlfA==",
+      "version": "1.45.1",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.45.1.tgz",
+      "integrity": "sha512-LF4CUUtrUu2TCpDw4mcrAIuYrEjVDfT1cHbJMfwnE2+1b8PZcFzPNgvZCvq2JfQ4aTjRCCHw5EJ2tmr2NSzdPg==",
       "bin": {
         "playwright-core": "cli.js"
       },
       "engines": {
-        "node": ">=16"
+        "node": ">=18"
       }
     },
     "node_modules/prelude-ls": {

--- a/e2e/package.json
+++ b/e2e/package.json
@@ -9,7 +9,7 @@
     "typecheck": "tsc --noEmit"
   },
   "dependencies": {
-    "@playwright/test": "^1.42.1"
+    "@playwright/test": "^1.45.1"
   },
   "devDependencies": {
     "@types/node": "^20.11.30",

--- a/e2e/tests/record.spec.ts
+++ b/e2e/tests/record.spec.ts
@@ -23,7 +23,7 @@ describe('POST /record/[slug]', async () => {
 
     // TEST: debug用データ取得が成功すること
     const resp2 = await context.get('/record/debug');
-    expect(resp2.ok()).toBeTruthy();
+    expect(resp2.status()).toBe(200);
 
     const rows = (await resp2.json()).rows as {
       Time: string;

--- a/e2e/tests/record.spec.ts
+++ b/e2e/tests/record.spec.ts
@@ -1,6 +1,19 @@
 import {test, expect, request} from '@playwright/test';
 import {describe} from 'node:test';
 
+describe('GET /viewer', async () => {
+  test('正常閲覧', async ({page}) => {
+    // 閲覧してconsoleエラーが出ないこと
+    const errors: Error[] = [];
+    page.on('pageerror', e => errors.push(e));
+    const resp = await page.goto('/viewer');
+    expect(resp?.status()).toBe(200);
+    expect(errors).toMatchObject([]);
+
+    // TODO: あれとこれのラベルとハコが表示されている、とか見てもいい
+  });
+});
+
 describe('POST /record', async () => {
   test('正常データ保存', async () => {
     const context = await request.newContext();

--- a/e2e/tests/record.spec.ts
+++ b/e2e/tests/record.spec.ts
@@ -1,7 +1,7 @@
 import {test, expect, request} from '@playwright/test';
 import {describe} from 'node:test';
 
-describe('POST /record/[slug]', async () => {
+describe('POST /record', async () => {
   test('正常データ保存', async () => {
     const context = await request.newContext();
 

--- a/e2e/tests/record.spec.ts
+++ b/e2e/tests/record.spec.ts
@@ -12,6 +12,19 @@ describe('GET /viewer', async () => {
 
     // TODO: あれとこれのラベルとハコが表示されている、とか見てもいい
   });
+
+  test('1分後にページ自動更新される', async ({page}) => {
+    const oneMinute = 1 * 60 * 1000;
+    test.setTimeout(oneMinute + 5000);
+
+    const resp = await page.goto('/viewer');
+    expect(resp?.status()).toBe(200);
+
+    const before = await page.content();
+    await page.waitForTimeout(oneMinute); // Refresherは本番以外では1分間隔なことに依存
+    const after = await page.content();
+    expect(before).not.toEqual(after);
+  });
 });
 
 describe('POST /record', async () => {


### PR DESCRIPTION
* シンプルに、非表示時にリフレッシュしないだけの変更
  - close #94
* これを自動テストしようとE2Eを整備したが、肝心の「非表示時」をplaywrightで再現できないことがわかり、テストできてない
  - テスト整備により #83 が進展した
* 非表示時判定には二種類のAPIが使えるが、差異があるのかないのか・どちらが推奨なのかなど全く分からなかったので、名前がシンプルでわかりやすい方を採用
  - https://developer.mozilla.org/ja/docs/Web/API/Document/visibilityState
  - https://developer.mozilla.org/ja/docs/Web/API/Document/hidden
* 非表示からの復帰で即時更新を入れても良かったが、まぁF5でいいのでは...？と思い、一旦入れてない。chromeosのapp modeだと更新ボタン無いので、それで不便ならいれるかも